### PR TITLE
Fix warning and naming conventions of ExpressionSet2phyloseq()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: curatedMetagenomicData
 Type: Package
 Title: Curated Metagenomic Data of the Human Microbiome
-Version: 1.1.1
+Version: 1.1.2
 Author:
     Levi Waldron <lwaldron.research@gmail.com>,
     Lucas Schiffer <schiffer.lucas@gmail.com>,

--- a/man/ExpressionSet2phyloseq.Rd
+++ b/man/ExpressionSet2phyloseq.Rd
@@ -4,14 +4,16 @@
 \alias{ExpressionSet2phyloseq}
 \title{Convert an ExpressionSet object to a phyloseq object}
 \usage{
-ExpressionSet2phyloseq(ExpressionSet, simplify = TRUE, rounding = TRUE)
+ExpressionSet2phyloseq(eset, simplify = TRUE, relab = TRUE)
 }
 \arguments{
-\item{ExpressionSet}{An ExpressionSet object}
+\item{eset}{An eset object}
 
 \item{simplify}{if TRUE the most detailed clade name is used}
 
-\item{rounding}{if TRUE values are rounded to the nearest interger}
+\item{relab}{if FALSE, values are multiplied by read depth to approximate counts,
+if TRUE (default) values kept as relative abundances between 0 and 
+100 %.}
 }
 \value{
 A phyloseq object


### PR DESCRIPTION
Don't re-assign imported functions and classes, use "." to denote data objects, change "rounding"
argument to "relab" argument.